### PR TITLE
fix Python 3.7 pyserial issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-# Just these two versions for now
+# Just these versions for now
   - "2.7"
   - "3.4"
+  - "3.7"
 install:
   - python setup.py install
 # Install coverage for nosetests

--- a/bc125csv/scanner.py
+++ b/bc125csv/scanner.py
@@ -112,7 +112,7 @@ class Scanner(serial.Serial, object):
         super(Scanner, self).__init__(port=port, baudrate=baudrate)
 
     def writeread(self, command): # pragma: no cover
-        self.write(command + "\r")
+        self.write((command + "\r").encode())
         self.flush()
         return self.readlinecr()
 
@@ -129,7 +129,7 @@ class Scanner(serial.Serial, object):
         """
         line = ""
         while True:
-            c = self.read(1)
+            c = self.read(1).decode()
             if c == "\r":
                 return line
             line += c


### PR DESCRIPTION
[gert@mars bc125csv]$ echo -en "PRG\nBLT,AO\nEPG" | bc125csv shell
Traceback (most recent call last):
  File "/usr/local/bin/bc125csv", line 11, in <module>
    load_entry_point('bc125csv==1.0.1', 'console_scripts', 'bc125csv')()
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/handler.py", line 386, in main
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/handler.py", line 182, in handle
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/handler.py", line 286, in command_shell
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/handler.py", line 220, in get_scanner
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/scanner.py", line 149, in get_model
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/scanner.py", line 120, in send
  File "/usr/local/lib/python3.7/site-packages/bc125csv-1.0.1-py3.7.egg/bc125csv/scanner.py", line 115, in writeread
  File "/usr/lib/python3.7/site-packages/serial/serialposix.py", line 532, in write
    d = to_bytes(data)
  File "/usr/lib/python3.7/site-packages/serial/serialutil.py", line 63, in to_bytes
    raise TypeError('unicode strings are not supported, please encode to bytes: {!r}'.format(seq))
TypeError: unicode strings are not supported, please encode to bytes: 'MDL\r'
[gert@mars bc125csv]$ 