### PR TITLE
Add support for SR30C and move away from pyudev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bc125csv
 =============
 
-Channel import and export tool for the Uniden BC125AT, UBC125XLT and UBC126AT.
+Channel import and export tool for the Uniden BC125AT, UBC125XLT, UBC126AT, and SR30C.
 
 [![Build Status](https://travis-ci.org/fdev/bc125csv.svg)](https://travis-ci.org/fdev/bc125csv)
 [![Code Climate](https://codeclimate.com/github/fdev/bc125csv/badges/gpa.svg)](https://codeclimate.com/github/fdev/bc125csv)
@@ -28,7 +28,6 @@ Requirements
 ------------
 
 * Python 2.7+ or 3.4+
-* [pyudev](https://pyudev.readthedocs.org/)
 * [pySerial](http://pyserial.sourceforge.net/)
 
 Both pyudev and pySerial will be automatically installed on installation.
@@ -192,8 +191,13 @@ include a carriage return yourself.
 Compatibility
 -------------
 
-This application is compatible with the Uniden Bearcat models BC125AT, UBC125XLT
-and UBC126AT.
+This application is compatible with the Uniden Bearcat models BC125AT, UBC125XLT,
+UBC126AT, and SR30C.
+
+Note: the SR30C uses a stock UART serial USB chipset (specifically, the CP2104).
+Linux kernel v2.6.12+ appears to have the driver, but in other operating systems
+it may be necessary to get drivers from the manufacturer:
+https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers
 
 
 License (MIT)

--- a/bc125csv/scanner.py
+++ b/bc125csv/scanner.py
@@ -42,7 +42,7 @@ DCS_CODES = [
     "732","734","743","754",
 ]
 
-SUPPORTED_MODELS = ("BC125AT", "UBC125XLT", "UBC126AT")
+SUPPORTED_MODELS = ("BC125AT", "UBC125XLT", "UBC126AT", "SR30C")
 
 
 class Channel(object):
@@ -100,8 +100,8 @@ class Scanner(serial.Serial, object):
         (?P<index>\d{1,3}),
         (?P<name>[^,]{0,16}),
         (?P<freq>\d{5,8}), # 4 decimals, so at least 5 digits
-        (?P<modulation>AUTO|AM|FM|NFM),
-        (?P<tq>\d{1,3}),
+        (?P<modulation>|AUTO|AM|FM|NFM),
+        (?P<tq>\d{0,3}),
         (?P<delay>-10|-5|0|1|2|3|4|5),
         (?P<lockout>0|1),
         (?P<priority>0|1) # no comma!
@@ -177,7 +177,7 @@ class Scanner(serial.Serial, object):
             "name":       data["name"].strip(),
             "frequency":  frequency,
             "modulation": data["modulation"],
-            "tqcode":     int(data["tq"]),
+            "tqcode":     int(data["tq"] or "0"),
             "delay":      int(data["delay"]),
             "lockout":    data["lockout"] == "1",
             "priority":   data["priority"] == "1",

--- a/bc125csv/scanner.py
+++ b/bc125csv/scanner.py
@@ -206,7 +206,10 @@ class Scanner(serial.Serial, object):
         if channel:
             result = self.send("DCH,%d" % index)
             if not result or result != "DCH,OK":
-                raise ScannerException("Could not delete channel %d." % index)
+                # Fall back to zeroing out the channel
+                result = self.send("CIN,%d,,00000000,,,0,1,0" % index)
+                if not result or result != "CIN,OK":
+                    raise ScannerException("Could not delete channel %d." % index)
 
 
 class VirtualScanner(Scanner):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-description = "Channel import and export tool for the BC125AT, UBC125XLT and UBC126AT."
+description = "Channel import and export tool for the BC125AT, UBC125XLT, UBC126AT, and SR30C."
 try:
 	# Convert from Markdown to reStructuredText (supported by PyPi).
 	import os

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
 	author = "Folkert de Vries",
 	author_email = "bc125csv@fdev.nl",
 	packages = ["bc125csv"],
-	install_requires = ["pyudev", "pyserial"],
+	install_requires = ["pyserial"],
 	entry_points="""
 	[console_scripts]
 	bc125csv = bc125csv:main


### PR DESCRIPTION
Great tool here. Not a lot of open source Uniden scanner programming stuff out there. I was looking for something minimalist since I did not feel like paying for that butel.nl tool that most people online seem to recommend.

The main objective was adding the SR30C device. There are a few quirks:
* It uses the same BC125AT protocol, but the unset channel looks like `CIN,1,,00000000,,,0,1,0` Even when a channel is set, if the modulation and tone columns are default (when writing `CIN,1,,01230000,AUTO,0,0,1,0` it is read back `CIN,1,,01230000,,,0,1,0`), then the value is not explicitly stated in the CIN data. I updated the regex and parse logic to handle this case.
* The SR30C uses a different chipset for its USB controller (the CP2104 from Silicon Laboratories). I modified the vendor detection. Also this chipset insists on using a 57600 baud rate. This is not documented anywhere on the internet, but that was the only baud rate that worked in my testing. 

Other Issue: Udev appears to be linux only https://github.com/pyudev/pyudev/issues/185 so my Mac did not work with this. I did find that the pyserial library has a way of iterating thru serial ports. I attempted to do a similar scanner discovery process as you have currently. Open question: you check for tty, but my Mac is fine using the cu device instead of the tty device. Is linux more picky about have a tty in particular. I can research this more if we need parity for that. There is no pyserial minimum version in the setup.py but maybe one should be provided since the search functionality seems to be added in a later version (3.0+) https://pyserial.readthedocs.io/en/latest/tools.html `Changed in version 3.0: returning ListPortInfo objects instead of a tuple`

I have tested this on Mac with a SR30C. I don't have easy access to any other OS's or scanners.